### PR TITLE
Make slash check in key

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ PORT = 4001
 @add_rule("/set")
 def set():
   key = request["body"].get("key")
+  if "/" in key:
+    raise
   value = request["body"].get("value")
   f = open(os.path.join(os.path.dirname(__file__), "data", key), "w")
   f.write(value)
@@ -21,6 +23,8 @@ def set():
 
 @add_rule("/set/<key>/<value>")
 def index(key, value):
+  if "/" in key:
+    raise
   f = open(os.path.join(os.path.dirname(__file__), "data", key), "w")
   f.write(unquote_plus(value))
   f.close()
@@ -30,6 +34,8 @@ def index(key, value):
 
 @add_rule("/del/<key>")
 def delete(key):
+  if "/" in key:
+    raise
   path = os.path.join(os.path.dirname(__file__), "data", key)
   exists = os.path.exists(path)
   if exists:
@@ -43,6 +49,8 @@ def delete(key):
 
 @add_rule("/get/<key>")
 def index(key):
+  if "/" in key:
+    raise
   exists = os.path.exists(os.path.join(os.path.dirname(__file__), "data", key))
   if exists:
     f = open(os.path.join(os.path.dirname(__file__), "data", key))
@@ -56,6 +64,8 @@ def index(key):
 
 @add_rule("/exists/<key>")
 def index(key):
+  if "/" in key:
+    raise
   exists = os.path.exists(os.path.join(os.path.dirname(__file__), "data", key))
   return json.dumps({
     "result": 1 if exists else 0


### PR DESCRIPTION
Double dots and slash allows me to go to upper folder. Deleting something from the upper folder curently possible. It is a strange though. If something like "open" was implemented in Python, the dev would definetely not allow to seek such a path name, but it does. So the python guy implementing the code that allows other dev to pass such a path name this path users/me/../me.